### PR TITLE
Adds Data.BitList to other-modules in lvish.cabal

### DIFF
--- a/haskell/lvish/lvish.cabal
+++ b/haskell/lvish/lvish.cabal
@@ -157,6 +157,7 @@ library
                     Data.Concurrent.Counter
                     Data.Concurrent.SNZI
                     Data.Concurrent.AlignedIORef
+                    Data.BitList
                     Control.LVish.SchedIdempotentInternal 
                     Control.LVish.Types
                     Control.LVish.Basics


### PR DESCRIPTION
This was picked up by `stack install` when compiling an executable that depends on lvish.

    Warning: module not listed in lvish.cabal for library component (add to other-modules): Data.BitList